### PR TITLE
Email subject wrongly uses WP_SITEURL instead of WP_HOME

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://l3rady.com/donate
 Tags: admin, theme, monitor, plugin, notification, upgrade, security
 Requires at least: 3.1
 Tested up to: 3.8.1
-Stable tag: 1.4
+Stable tag: 1.4.1
 
 Sends email to notify you if there are any updates for your WordPress site. Can notify about core, plugin and theme updates.
 
@@ -52,6 +52,9 @@ This plugin is a fork of [Update Notifier](http://wordpress.org/extend/plugins/u
 2. Email alert
 
 == Changelog ==
+
+= 1.4.1 =
+* Switch from using site_url() to home_url() in email subject line so not to link to a 404 page.
 
 = 1.4 =
 * Added external cron method allowing users check for updates as often or as little as they want

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -4,7 +4,7 @@ Plugin Name: WP Updates Notifier
 Plugin URI: https://github.com/l3rady/wp-updates-notifier
 Description: Sends email to notify you if there are any updates for your WordPress site. Can notify about core, plugin and theme updates.
 Author: Scott Cariss
-Version: 1.4
+Version: 1.4.1
 Author URI: http://l3rady.com/
 Text Domain: wp-updates-notifier
 Domain Path: /languages


### PR DESCRIPTION
Currently, the emails which are generated by this plugin have this in the Subject field:

WP Updates Notifier: Updates Available @ http://example.com

As far as I can tell, the plugin is using the value of WP_SITEURL to determine the URL to put there in the subject.

Assuming that is correct, I'd like to ask if the plugin can instead use the value of WP_HOME.

The reason is that many people have WordPress installed into a subdirectory (which is supported and documented by the WP Codex). Therefore the value of WP_SITEURL would be something like http://example.com/wordpress, while the value of WP_HOME would be the actual website URL, http://example.com which is the URL that should appear in the subject of these emails.

If someone were to click on the URL in the subject, when it points to the subdirectory location (http://example.com/wordpress), they would get a 404 error because it's an invalid URL.
