### PR TITLE
Same email address used for core automatic updates

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: l3rady
 Donate link: http://l3rady.com/donate
 Tags: admin, theme, monitor, plugin, notification, upgrade, security
 Requires at least: 3.1
-Tested up to: 3.8.1
-Stable tag: 1.4.1
+Tested up to: 4.1
+Stable tag: 1.4.2
 
 Sends email to notify you if there are any updates for your WordPress site. Can notify about core, plugin and theme updates.
 
@@ -52,6 +52,9 @@ This plugin is a fork of [Update Notifier](http://wordpress.org/extend/plugins/u
 2. Email alert
 
 == Changelog ==
+
+= 1.4.2 =
+* Added an option that allow the plugin to notify the provided email about WordPress core automatic updates.
 
 = 1.4.1 =
 * Switch from using site_url() to home_url() in email subject line so not to link to a 404 page.

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -457,8 +457,14 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		public function filter_auto_core_update_email( $email ) {
 			$options = self::getSetOptions( self::OPT_FIELD ); // Get settings
 
-			if ( 0 != $options['notify_automatic'] && ! empty( $options['notify_to'] ) ) { // If an email address has been set, override the WordPress default.
-				$email['to'] = $options['notify_to'];
+			if ( 0 != $options['notify_automatic'] ) {
+				if ( ! empty( $options['notify_to'] ) ) { // If an email address has been set, override the WordPress default.
+					$email['to'] = $options['notify_to'];
+				}
+
+				if ( ! empty( $options['notify_from'] ) ) { // If an email address has been set, override the WordPress default.
+					$email['header'][] = 'From: ' . self::sc_wpun_wp_mail_from_name() . ' <' . $options['notify_from'] . '>';
+				}
 			}
 
 			return $email;

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -463,7 +463,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 				}
 
 				if ( ! empty( $options['notify_from'] ) ) { // If an email address has been set, override the WordPress default.
-					$email['header'][] = 'From: ' . self::sc_wpun_wp_mail_from_name() . ' <' . $options['notify_from'] . '>';
+					$email['headers'][] = 'From: ' . self::sc_wpun_wp_mail_from_name() . ' <' . $options['notify_from'] . '>';
 				}
 			}
 

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -4,7 +4,7 @@ Plugin Name: WP Updates Notifier
 Plugin URI: https://github.com/l3rady/wp-updates-notifier
 Description: Sends email to notify you if there are any updates for your WordPress site. Can notify about core, plugin and theme updates.
 Author: Scott Cariss
-Version: 1.4.1
+Version: 1.4.2
 Author URI: http://l3rady.com/
 Text Domain: wp-updates-notifier
 Domain Path: /languages


### PR DESCRIPTION
Added the option to recieve core automatic updates emails to the same email address as other updates notifications.

I'm now waiting for a minor auto update on my website to test if this is working or not... :)