### PR TITLE
Enable filtering of wp_mail subject and message, update readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -109,13 +109,13 @@ This plugin is a fork of [Update Notifier](http://wordpress.org/extend/plugins/u
 
 = 1.4.3 =
 * Repaired all PHP errors being thrown
-* Two new filters added to allow you to alter the email content (updates_notifier_email_subject, updates_notifier_email_content - see readme.txt for examples)
+* Two new filters added to allow you to alter the email content (sc_wpun_email_subject, sc_wpun_email_content - see readme.txt for examples)
 
 == Filters ==
 
 Two filters have been provided to allow you to alter the email subject and email content being sent by WP Updates Notifier.
 
-<h4>updates_notifier_email_subject</h4>
+<h4>sc_wpun_email_subject</h4>
 
 @parameters:<br /> 
 $email_subject - the email subject to be filtered.
@@ -125,14 +125,14 @@ $email_subject - the email subject to be filtered.
 /* 
 *	Alter the email subject being sent by WP Updates Notifier 
 */
-function alter_email_subject_in_updates_notifier( $email_subject ) {
+function alter_wp_updates_notifier_email_subject( $email_subject ) {
 	$email_subject = 'This is the new email subject for updates notifier';
 	return $email_subject;
 }
-add_filter( 'updates_notifier_email_subject', 'alter_email_subject_in_updates_notifier' );
+add_filter( 'sc_wpun_email_subject', 'alter_wp_updates_notifier_email_subject' );
 `
 
-<h4>updates_notifier_email_content</h4>
+<h4>sc_wpun_email_content</h4>
 
 @parameters:<br />
 $message - the content of the email to be filtered
@@ -142,9 +142,9 @@ $message - the content of the email to be filtered
 /* 
 *	Alter the email content being sent by WP Updates Notifier 
 */
-function alter_email_content_in_updates_notifier( $message ) {
+function alter_wp_updates_notifier_email_content( $message ) {
 	$message = 'This is our new email content that will override the default.';
 	return $message;
 }
-add_filter( 'updates_notifier_email_content', 'alter_email_content_in_updates_notifier' );
+add_filter( 'sc_wpun_email_content', 'alter_wp_updates_notifier_email_content' );
 `

--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: admin, theme, monitor, plugin, notification, upgrade, security
 Requires at least: 3.1
 Tested up to: 4.3
 Stable tag: 1.4.3
+License: GPLv3 or later
 
 Sends email to notify you if there are any updates for your WordPress site. Can notify about core, plugin and theme updates.
 
@@ -104,13 +105,20 @@ This plugin is a fork of [Update Notifier](http://wordpress.org/extend/plugins/u
 = 1.0 =
 * Initial release
 
+== Upgrade Notice ==
+
+= 1.4.3 =
+* Repaired all PHP errors being thrown
+* Two new filters added to allow you to alter the email content (updates_notifier_email_subject, updates_notifier_email_content - see readme.txt for examples)
+
 == Filters ==
 
 Two filters have been provided to allow you to alter the email subject and email content being sent by WP Updates Notifier.
 
-`updates_notifier_email_subject`
+<h4>updates_notifier_email_subject</h4>
 
-@parameters: $email_subject - the email subject to be filtered.
+@parameters:<br /> 
+$email_subject - the email subject to be filtered.
 
 <strong>Example:</strong>
 `
@@ -124,9 +132,10 @@ function alter_email_subject_in_updates_notifier( $email_subject ) {
 add_filter( 'updates_notifier_email_subject', 'alter_email_subject_in_updates_notifier' );
 `
 
-`updates_notifier_email_content`
+<h4>updates_notifier_email_content</h4>
 
-@parameters: $message - the content of the email to be filtered
+@parameters:<br />
+$message - the content of the email to be filtered
 
 <strong>Example:</strong>
 `

--- a/readme.txt
+++ b/readme.txt
@@ -103,3 +103,39 @@ This plugin is a fork of [Update Notifier](http://wordpress.org/extend/plugins/u
 
 = 1.0 =
 * Initial release
+
+== Filters ==
+
+Two filters have been provided to allow you to alter the email subject and email content being sent by WP Updates Notifier.
+
+`updates_notifier_email_subject`
+
+@parameters: $email_subject - the email subject to be filtered.
+
+<strong>Example:</strong>
+`
+/* 
+*	Alter the email subject being sent by WP Updates Notifier 
+*/
+function alter_email_subject_in_updates_notifier( $email_subject ) {
+	$email_subject = 'This is the new email subject for updates notifier';
+	return $email_subject;
+}
+add_filter( 'updates_notifier_email_subject', 'alter_email_subject_in_updates_notifier' );
+`
+
+`updates_notifier_email_content`
+
+@parameters: $message - the content of the email to be filtered
+
+<strong>Example:</strong>
+`
+/* 
+*	Alter the email content being sent by WP Updates Notifier 
+*/
+function alter_email_content_in_updates_notifier( $message ) {
+	$message = 'This is our new email content that will override the default.';
+	return $message;
+}
+add_filter( 'updates_notifier_email_content', 'alter_email_content_in_updates_notifier' );
+`

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -7,6 +7,7 @@ Contribuors: Scott Cariss, eherman24
 Version: 1.4.2
 Text Domain: wp-updates-notifier
 Domain Path: /languages
+License: GPL3+
 */
 
 /*  Copyright 2014  Scott Cariss  (email : scott@l3rady.com)

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -420,7 +420,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 			add_filter( 'wp_mail_from', array( __CLASS__, 'sc_wpun_wp_mail_from' ) ); // add from filter
 			add_filter( 'wp_mail_from_name', array( __CLASS__, 'sc_wpun_wp_mail_from_name' ) ); // add from name filter
 			add_filter( 'wp_mail_content_type', array( __CLASS__, 'sc_wpun_wp_mail_content_type' ) ); // add content type filter
-			wp_mail( $settings['notify_to'], apply_filters( 'updates_notifier_email_subject', $subject ), apply_filters( 'updates_notifier_email_content', $message ) ); // send email
+			wp_mail( $settings['notify_to'], apply_filters( 'sc_wpun_email_subject', $subject ), apply_filters( 'sc_wpun_email_content', $message ) ); // send email
 			remove_filter( 'wp_mail_from', array( __CLASS__, 'sc_wpun_wp_mail_from' ) ); // remove from filter
 			remove_filter( 'wp_mail_from_name', array( __CLASS__, 'sc_wpun_wp_mail_from_name' ) ); // remove from name filter
 			remove_filter( 'wp_mail_content_type', array( __CLASS__, 'sc_wpun_wp_mail_content_type' ) ); // remove content type filter

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -61,7 +61,6 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 			add_action( 'wp_ajax_nopriv_sc_wpun_check', array( __CLASS__, 'sc_wpun_check' ) ); // Admin ajax hook for remote cron method.
 		}
 
-
 		/**
 		 * Check if this plugin settings are up to date. Firstly check the version in
 		 * the DB. If they don't match then load in defaults but don't override values
@@ -420,7 +419,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 			add_filter( 'wp_mail_from', array( __CLASS__, 'sc_wpun_wp_mail_from' ) ); // add from filter
 			add_filter( 'wp_mail_from_name', array( __CLASS__, 'sc_wpun_wp_mail_from_name' ) ); // add from name filter
 			add_filter( 'wp_mail_content_type', array( __CLASS__, 'sc_wpun_wp_mail_content_type' ) ); // add content type filter
-			wp_mail( $settings['notify_to'], $subject, $message ); // send email
+			wp_mail( $settings['notify_to'], apply_filters( 'updates_notifier_email_subject', $subject ), apply_filters( 'updates_notifier_email_content', $message ) ); // send email
 			remove_filter( 'wp_mail_from', array( __CLASS__, 'sc_wpun_wp_mail_from' ) ); // remove from filter
 			remove_filter( 'wp_mail_from_name', array( __CLASS__, 'sc_wpun_wp_mail_from_name' ) ); // remove from name filter
 			remove_filter( 'wp_mail_content_type', array( __CLASS__, 'sc_wpun_wp_mail_content_type' ) ); // remove content type filter


### PR DESCRIPTION
Hi @l3rady,

This PR enables two new filters inside of the wp_mail() function to allow users to alter the email subject and/or the email content.

I got the idea from the following idea in the WordPress repository, and thought it was a decent idea and went ahead and implemented it.
https://wordpress.org/support/topic/enhancement-allow-filtering-of-message-sent?replies=1

I also added some instruction & examples relating to the new filters to the readme, added a license to the plugin header and readme files.

I tested the filters and they are working as expected.


Evan