### PR TITLE
Fix oop style

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: l3rady, eherman24
 Donate link: http://l3rady.com/donate
 Tags: admin, theme, monitor, plugin, notification, upgrade, security
 Requires at least: 3.1
-Tested up to: 4.3
-Stable tag: 1.4.3
+Tested up to: 4.5.3
+Stable tag: 1.4.4
 License: GPLv3 or later
 
 Sends email to notify you if there are any updates for your WordPress site. Can notify about core, plugin and theme updates.
@@ -53,6 +53,11 @@ This plugin is a fork of [Update Notifier](http://wordpress.org/extend/plugins/u
 2. Email alert
 
 == Changelog ==
+
+= 1.4.4=
+* Avoid PHP Strict notices
+* PHP 7 compatibility
+* Minor cleanup on some internal code
 
 = 1.4.3 =
 * Repaired all PHP errors being thrown

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -39,29 +39,33 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		const OPT_VERSION       = "5.0";
 		const CRON_NAME         = "sc_wpun_update_check";
 
-		public static function init() {
+		public function __construct() {
+			$this->init();
+		}
+
+		protected function init() {
 			// Check settings are up to date
-			self::settingsUpToDate();
+			$this->settingsUpToDate();
 			// Create Activation and Deactivation Hooks
-			register_activation_hook( __FILE__, array( __CLASS__, 'activate' ) );
-			register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivate' ) );
+			register_activation_hook( __FILE__, array( $this, 'activate' ) );
+			register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
 			// Internationalization
 			load_plugin_textdomain( 'wp-updates-notifier', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 			// Add Filters
-			add_filter( 'plugin_action_links', array( __CLASS__, 'plugin_action_links' ), 10, 2 ); // Add settings link to plugin in plugin list
-			add_filter( 'sc_wpun_plugins_need_update', array( __CLASS__, 'check_plugins_against_notified' ) ); // Filter out plugins that need update if already been notified
-			add_filter( 'sc_wpun_themes_need_update', array( __CLASS__, 'check_themes_against_notified' ) ); // Filter out themes that need update if already been notified
-			add_filter( 'auto_core_update_email', array( __CLASS__, 'filter_auto_core_update_email' ), 1 ); // Filter the background update notification email.
+			add_filter( 'plugin_action_links', array( $this, 'plugin_action_links' ), 10, 2 ); // Add settings link to plugin in plugin list
+			add_filter( 'sc_wpun_plugins_need_update', array( $this, 'check_plugins_against_notified' ) ); // Filter out plugins that need update if already been notified
+			add_filter( 'sc_wpun_themes_need_update', array( $this, 'check_themes_against_notified' ) ); // Filter out themes that need update if already been notified
+			add_filter( 'auto_core_update_email', array( $this, 'filter_auto_core_update_email' ), 1 ); // Filter the background update notification email.
 			// Add Actions
-			add_action( 'admin_menu', array( __CLASS__, 'admin_settings_menu' ) ); // Add menu to options
-			add_action( 'admin_init', array( __CLASS__, 'admin_settings_init' ) ); // Add admin init functions
-			add_action( 'admin_init', array( __CLASS__, 'remove_update_nag_for_nonadmins' ) ); // See if we remove update nag for non admins
-			add_action( 'admin_init', array( __CLASS__, 'admin_register_scripts_styles' ) );
-			add_action( 'sc_wpun_enable_cron', array( __CLASS__, 'enable_cron' ) ); // action to enable cron
-			add_action( 'sc_wpun_disable_cron', array( __CLASS__, 'disable_cron' ) ); // action to disable cron
-			add_action( self::CRON_NAME, array( __CLASS__, 'do_update_check' ) ); // action to link cron task to actual task
-			add_action( 'wp_ajax_sc_wpun_check', array( __CLASS__, 'sc_wpun_check' ) ); // Admin ajax hook for remote cron method.
-			add_action( 'wp_ajax_nopriv_sc_wpun_check', array( __CLASS__, 'sc_wpun_check' ) ); // Admin ajax hook for remote cron method.
+			add_action( 'admin_menu', array( $this, 'admin_settings_menu' ) ); // Add menu to options
+			add_action( 'admin_init', array( $this, 'admin_settings_init' ) ); // Add admin init functions
+			add_action( 'admin_init', array( $this, 'remove_update_nag_for_nonadmins' ) ); // See if we remove update nag for non admins
+			add_action( 'admin_init', array( $this, 'admin_register_scripts_styles' ) );
+			add_action( 'sc_wpun_enable_cron', array( $this, 'enable_cron' ) ); // action to enable cron
+			add_action( 'sc_wpun_disable_cron', array( $this, 'disable_cron' ) ); // action to disable cron
+			add_action( self::CRON_NAME, array( $this, 'do_update_check' ) ); // action to link cron task to actual task
+			add_action( 'wp_ajax_sc_wpun_check', array( $this, 'sc_wpun_check' ) ); // Admin ajax hook for remote cron method.
+			add_action( 'wp_ajax_nopriv_sc_wpun_check', array( $this, 'sc_wpun_check' ) ); // Admin ajax hook for remote cron method.
 		}
 
 		/**
@@ -71,8 +75,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		private static function settingsUpToDate() {
-			$current_ver = self::getSetOptions( self::OPT_VERSION_FIELD ); // Get current plugin version
+		private function settingsUpToDate() {
+			$current_ver = $this->getSetOptions( self::OPT_VERSION_FIELD ); // Get current plugin version
 			if ( self::OPT_VERSION != $current_ver ) { // is the version the same as this plugin?
 				$options  = (array) get_option( self::OPT_FIELD ); // get current settings from DB
 				$defaults = array( // Here are our default values for this plugin
@@ -96,8 +100,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 				$options = array_intersect_key( $options, $defaults );
 				// Merge current settings with defaults. Basically adding any new settings with defaults that we dont have.
 				$options = array_merge( $defaults, $options );
-				self::getSetOptions( self::OPT_FIELD, $options ); // update settings
-				self::getSetOptions( self::OPT_VERSION_FIELD, self::OPT_VERSION ); // update settings version
+				$this->getSetOptions( self::OPT_FIELD, $options ); // update settings
+				$this->getSetOptions( self::OPT_VERSION_FIELD, self::OPT_VERSION ); // update settings version
 			}
 		}
 
@@ -110,7 +114,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return bool|mixed True or false if setting or an array of settings if getting
 		 */
-		private static function getSetOptions( $field, $settings = false ) {
+		private function getSetOptions( $field, $settings = false ) {
 			if ( $settings === false ) {
 				return apply_filters( 'sc_wpun_get_options_filter', get_option( $field ), $field );
 			}
@@ -124,7 +128,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		public static function activate() {
+		public function activate() {
 			do_action( "sc_wpun_enable_cron" ); // Enable cron
 		}
 
@@ -134,7 +138,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		public static function deactivate() {
+		public function deactivate() {
 			do_action( "sc_wpun_disable_cron" ); // Disable cron
 		}
 
@@ -146,8 +150,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		public static function enable_cron( $manual_interval = false ) {
-			$options         = self::getSetOptions( self::OPT_FIELD ); // Get settings
+		public function enable_cron( $manual_interval = false ) {
+			$options         = $this->getSetOptions( self::OPT_FIELD ); // Get settings
 			$currentSchedule = wp_get_schedule( self::CRON_NAME ); // find if a schedule already exists
 
 			// if a manual cron interval is set, use this
@@ -165,7 +169,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 				}
 
 				// check the cron setting is valid
-				if ( !in_array( $options['frequency'], self::get_intervals() ) ) {
+				if ( !in_array( $options['frequency'], $this->get_intervals() ) ) {
 					return;
 				}
 
@@ -183,7 +187,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		public static function disable_cron() {
+		public function disable_cron() {
 			wp_clear_scheduled_hook( self::CRON_NAME ); // clear cron
 		}
 
@@ -196,12 +200,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return array $links
 		 */
-		public static function plugin_action_links( $links, $file ) {
-			static $this_plugin;
-			if ( !$this_plugin ) {
-				$this_plugin = plugin_basename( __FILE__ );
-			}
-			if ( $file == $this_plugin ) {
+		public function plugin_action_links( $links, $file ) {
+			if ( $file == plugin_basename( __FILE__ ) ) {
 				$settings_link = '<a href="' . admin_url( 'options-general.php?page=wp-updates-notifier' ) . '">' . __( "Settings", "wp-updates-notifier" ) . '</a>';
 				array_unshift( $links, $settings_link );
 			}
@@ -215,18 +215,18 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		public static function do_update_check() {
-			$options      = self::getSetOptions( self::OPT_FIELD ); // get settings
+		public function do_update_check() {
+			$options      = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			$message      = ""; // start with a blank message
-			$core_updated = self::core_update_check( $message ); // check the WP core for updates
+			$core_updated = $this->core_update_check( $message ); // check the WP core for updates
 			if ( 0 != $options['notify_plugins'] ) { // are we to check for plugin updates?
-				$plugins_updated = self::plugins_update_check( $message, $options['notify_plugins'] ); // check for plugin updates
+				$plugins_updated = $this->plugins_update_check( $message, $options['notify_plugins'] ); // check for plugin updates
 			}
 			else {
 				$plugins_updated = false; // no plugin updates
 			}
 			if ( 0 != $options['notify_themes'] ) { // are we to check for theme updates?
-				$themes_updated = self::themes_update_check( $message, $options['notify_themes'] ); // check for theme updates
+				$themes_updated = $this->themes_update_check( $message, $options['notify_themes'] ); // check for theme updates
 			}
 			else {
 				$themes_updated = false; // no theme updates
@@ -234,10 +234,10 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 			if ( $core_updated || $plugins_updated || $themes_updated ) { // Did anything come back as need updating?
 				$message = __( "There are updates available for your WordPress site:", "wp-updates-notifier" ) . "\n" . $message . "\n";
 				$message .= sprintf( __( "Please visit %s to update.", "wp-updates-notifier" ), admin_url( 'update-core.php' ) );
-				self::send_notification_email( $message ); // send our notification email.
+				$this->send_notification_email( $message ); // send our notification email.
 			}
 
-			self::log_last_check_time();
+			$this->log_last_check_time();
 		}
 
 
@@ -248,9 +248,9 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return bool
 		 */
-		private static function core_update_check( &$message ) {
+		private function core_update_check( &$message ) {
 			global $wp_version;
-			$settings = self::getSetOptions( self::OPT_FIELD ); // get settings
+			$settings = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			do_action( "wp_version_check" ); // force WP to check its core for updates
 			$update_core = get_site_transient( "update_core" ); // get information of updates
 			if ( 'upgrade' == $update_core->updates[0]->response ) { // is WP core update available?
@@ -260,7 +260,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 					$old_core_ver = $wp_version; // the old WP core version
 					$message .= "\n" . sprintf( __( "WP-Core: WordPress is out of date. Please update from version %s to %s", "wp-updates-notifier" ), $old_core_ver, $new_core_ver ) . "\n";
 					$settings['notified']['core'] = $new_core_ver; // set core version we are notifying about
-					self::getSetOptions( self::OPT_FIELD, $settings ); // update settings
+					$this->getSetOptions( self::OPT_FIELD, $settings ); // update settings
 					return true; // we have updates so return true
 				}
 				else {
@@ -268,7 +268,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 				}
 			}
 			$settings['notified']['core'] = ""; // no updates lets set this nothing
-			self::getSetOptions( self::OPT_FIELD, $settings ); // update settings
+			$this->getSetOptions( self::OPT_FIELD, $settings ); // update settings
 			return false; // no updates return false
 		}
 
@@ -281,10 +281,10 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return bool
 		 */
-		private static function plugins_update_check( &$message, $allOrActive ) {
+		private function plugins_update_check( &$message, $allOrActive ) {
 			global $wp_version;
 			$cur_wp_version = preg_replace( '/-.*$/', '', $wp_version );
-			$settings       = self::getSetOptions( self::OPT_FIELD ); // get settings
+			$settings       = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			do_action( "wp_update_plugins" ); // force WP to check plugins for updates
 			$update_plugins = get_site_transient( 'update_plugins' ); // get information of updates
 			if ( !empty( $update_plugins->response ) ) { // any plugin updates available?
@@ -316,14 +316,14 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 						$message .= "\t" . sprintf( __( "Compatibility: %s", "wp-updates-notifier" ), $compat ) . "\n";
 						$settings['notified']['plugin'][$key] = $data->new_version; // set plugin version we are notifying about
 					}
-					self::getSetOptions( self::OPT_FIELD, $settings ); // save settings
+					$this->getSetOptions( self::OPT_FIELD, $settings ); // save settings
 					return true; // we have plugin updates return true
 				}
 			}
 			else {
 				if ( 0 != count( $settings['notified']['plugin'] ) ) { // is there any plugin notifications?
 					$settings['notified']['plugin'] = array(); // set plugin notifications to empty as all plugins up-to-date
-					self::getSetOptions( self::OPT_FIELD, $settings ); // save settings
+					$this->getSetOptions( self::OPT_FIELD, $settings ); // save settings
 				}
 			}
 			return false; // No plugin updates so return false
@@ -338,8 +338,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return bool
 		 */
-		private static function themes_update_check( &$message, $allOrActive ) {
-			$settings = self::getSetOptions( self::OPT_FIELD ); // get settings
+		private function themes_update_check( &$message, $allOrActive ) {
+			$settings = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			do_action( "wp_update_themes" ); // force WP to check for theme updates
 			$update_themes = get_site_transient( 'update_themes' ); // get information of updates
 			if ( !empty( $update_themes->response ) ) { // any theme updates available?
@@ -355,14 +355,14 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 						$message .= "\n" . sprintf( __( "Theme: %s is out of date. Please update from version %s to %s", "wp-updates-notifier" ), $theme_info['Name'], $theme_info['Version'], $data['new_version'] ) . "\n";
 						$settings['notified']['theme'][$key] = $data['new_version']; // set theme version we are notifying about
 					}
-					self::getSetOptions( self::OPT_FIELD, $settings ); // save settings
+					$this->getSetOptions( self::OPT_FIELD, $settings ); // save settings
 					return true; // we have theme updates return true
 				}
 			}
 			else {
 				if ( 0 != count( $settings['notified']['theme'] ) ) { // is there any theme notifications?
 					$settings['notified']['theme'] = array(); // set theme notifications to empty as all themes up-to-date
-					self::getSetOptions( self::OPT_FIELD, $settings ); // save settings
+					$this->getSetOptions( self::OPT_FIELD, $settings ); // save settings
 				}
 			}
 			return false; // No theme updates so return false
@@ -376,8 +376,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return array $plugins_need_update
 		 */
-		public static function check_plugins_against_notified( $plugins_need_update ) {
-			$settings = self::getSetOptions( self::OPT_FIELD ); // get settings
+		public function check_plugins_against_notified( $plugins_need_update ) {
+			$settings = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			foreach ( $plugins_need_update as $key => $data ) { // loop through plugins that need update
 				if ( isset( $settings['notified']['plugin'][$key] ) ) { // has this plugin been notified before?
 					if ( $data->new_version == $settings['notified']['plugin'][$key] ) { // does this plugin version match that of the one that's been notified?
@@ -396,8 +396,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return array $themes_need_update
 		 */
-		public static function check_themes_against_notified( $themes_need_update ) {
-			$settings = self::getSetOptions( self::OPT_FIELD ); // get settings
+		public function check_themes_against_notified( $themes_need_update ) {
+			$settings = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			foreach ( $themes_need_update as $key => $data ) { // loop through themes that need update
 				if ( isset( $settings['notified']['theme'][$key] ) ) { // has this theme been notified before?
 					if ( $data['new_version'] == $settings['notified']['theme'][$key] ) { // does this theme version match that of the one that's been notified?
@@ -416,36 +416,36 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		public static function send_notification_email( $message ) {
-			$settings = self::getSetOptions( self::OPT_FIELD ); // get settings
+		public function send_notification_email( $message ) {
+			$settings = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			$subject  = sprintf( __( "WP Updates Notifier: Updates Available @ %s", "wp-updates-notifier" ), home_url() );
-			add_filter( 'wp_mail_from', array( __CLASS__, 'sc_wpun_wp_mail_from' ) ); // add from filter
-			add_filter( 'wp_mail_from_name', array( __CLASS__, 'sc_wpun_wp_mail_from_name' ) ); // add from name filter
-			add_filter( 'wp_mail_content_type', array( __CLASS__, 'sc_wpun_wp_mail_content_type' ) ); // add content type filter
+			add_filter( 'wp_mail_from', array( $this, 'sc_wpun_wp_mail_from' ) ); // add from filter
+			add_filter( 'wp_mail_from_name', array( $this, 'sc_wpun_wp_mail_from_name' ) ); // add from name filter
+			add_filter( 'wp_mail_content_type', array( $this, 'sc_wpun_wp_mail_content_type' ) ); // add content type filter
 			wp_mail( $settings['notify_to'], apply_filters( 'sc_wpun_email_subject', $subject ), apply_filters( 'sc_wpun_email_content', $message ) ); // send email
-			remove_filter( 'wp_mail_from', array( __CLASS__, 'sc_wpun_wp_mail_from' ) ); // remove from filter
-			remove_filter( 'wp_mail_from_name', array( __CLASS__, 'sc_wpun_wp_mail_from_name' ) ); // remove from name filter
-			remove_filter( 'wp_mail_content_type', array( __CLASS__, 'sc_wpun_wp_mail_content_type' ) ); // remove content type filter
+			remove_filter( 'wp_mail_from', array( $this, 'sc_wpun_wp_mail_from' ) ); // remove from filter
+			remove_filter( 'wp_mail_from_name', array( $this, 'sc_wpun_wp_mail_from_name' ) ); // remove from name filter
+			remove_filter( 'wp_mail_content_type', array( $this, 'sc_wpun_wp_mail_content_type' ) ); // remove content type filter
 		}
 
-		public static function sc_wpun_wp_mail_from() {
-			$settings = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_wp_mail_from() {
+			$settings = $this->getSetOptions( self::OPT_FIELD );
 			return $settings['notify_from'];
 		}
 
-		public static function sc_wpun_wp_mail_from_name() {
+		public function sc_wpun_wp_mail_from_name() {
 			return __( "WP Updates Notifier", "wp-updates-notifier" );
 		}
 
-		public static function sc_wpun_wp_mail_content_type() {
+		public function sc_wpun_wp_mail_content_type() {
 			return "text/plain";
 		}
 
 
-		private static function log_last_check_time() {
-			$options                    = self::getSetOptions( self::OPT_FIELD );
+		private function log_last_check_time() {
+			$options                    = $this->getSetOptions( self::OPT_FIELD );
 			$options['last_check_time'] = current_time( "timestamp" );
-			self::getSetOptions( self::OPT_FIELD, $options );
+			$this->getSetOptions( self::OPT_FIELD, $options );
 		}
 
 		/**
@@ -455,8 +455,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return array Modified array containing the new email address.
 		 */
-		public static function filter_auto_core_update_email( $email ) {
-			$options = self::getSetOptions( self::OPT_FIELD ); // Get settings
+		public function filter_auto_core_update_email( $email ) {
+			$options = $this->getSetOptions( self::OPT_FIELD ); // Get settings
 
 			if ( 0 != $options['notify_automatic'] ) {
 				if ( ! empty( $options['notify_to'] ) ) { // If an email address has been set, override the WordPress default.
@@ -464,7 +464,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 				}
 
 				if ( ! empty( $options['notify_from'] ) ) { // If an email address has been set, override the WordPress default.
-					$email['headers'][] = 'From: ' . self::sc_wpun_wp_mail_from_name() . ' <' . $options['notify_from'] . '>';
+					$email['headers'][] = 'From: ' . $this->sc_wpun_wp_mail_from_name() . ' <' . $options['notify_from'] . '>';
 				}
 			}
 
@@ -477,8 +477,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 *
 		 * @return void
 		 */
-		public static function remove_update_nag_for_nonadmins() {
-			$settings = self::getSetOptions( self::OPT_FIELD ); // get settings
+		public function remove_update_nag_for_nonadmins() {
+			$settings = $this->getSetOptions( self::OPT_FIELD ); // get settings
 			if ( 1 == $settings['hide_updates'] ) { // is this enabled?
 				if ( !current_user_can( 'update_plugins' ) ) { // can the current user update plugins?
 					remove_action( 'admin_notices', 'update_nag', 3 ); // no they cannot so remove the nag for them.
@@ -490,39 +490,39 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		/**
 		 * Adds JS to admin settings screen for this plugin
 		 */
-		public static function admin_register_scripts_styles() {
+		public function admin_register_scripts_styles() {
 			wp_register_script( 'wp_updates_monitor_js_function', plugins_url( 'js/function.js', __FILE__ ), array( 'jquery' ), '1.0', true );
 		}
 
 
-		public static function sc_wpun_check() {
-			$options = self::getSetOptions( self::OPT_FIELD ); // get settings
+		public function sc_wpun_check() {
+			$options = $this->getSetOptions( self::OPT_FIELD ); // get settings
 
 			if ( !isset( $_GET['sc_wpun_key'] ) || $options['security_key'] != $_GET['sc_wpun_key'] || "other" != $options['cron_method'] ) {
 				return;
 			}
 
-			self::do_update_check();
+			$this->do_update_check();
 
 			die( __( "Successfully checked for updates.", "wp-updates-notifier" ) );
 		}
 
 
-		private static function get_schedules() {
+		private function get_schedules() {
 			$schedules = wp_get_schedules();
-			uasort( $schedules, array( __CLASS__, 'sort_by_interval' ) );
+			uasort( $schedules, array( $this, 'sort_by_interval' ) );
 			return $schedules;
 		}
 
 
-		private static function get_intervals() {
-			$intervals   = array_keys( self::get_schedules() );
+		private function get_intervals() {
+			$intervals   = array_keys( $this->get_schedules() );
 			$intervals[] = "manual";
 			return $intervals;
 		}
 
 
-		private static function sort_by_interval( $a, $b ) {
+		private function sort_by_interval( $a, $b ) {
 			return $a['interval'] - $b['interval'];
 		}
 
@@ -533,17 +533,17 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		 * I'm not going to comment any of this as its all pretty
 		 * much straight forward use of the WordPress Settings API.
 		 */
-		public static function admin_settings_menu() {
-			$page = add_options_page( 'Updates Notifier', 'Updates Notifier', 'manage_options', 'wp-updates-notifier', array( __CLASS__, 'settings_page' ) );
-			add_action( "admin_print_scripts-{$page}", array( __CLASS__, 'enqueue_plugin_script' ) );
+		public function admin_settings_menu() {
+			$page = add_options_page( 'Updates Notifier', 'Updates Notifier', 'manage_options', 'wp-updates-notifier', array( $this, 'settings_page' ) );
+			add_action( "admin_print_scripts-{$page}", array( $this, 'enqueue_plugin_script' ) );
 		}
 
-		public static function enqueue_plugin_script() {
+		public function enqueue_plugin_script() {
 			wp_enqueue_script( 'wp_updates_monitor_js_function' );
 		}
 
-		public static function settings_page() {
-			$options     = self::getSetOptions( self::OPT_FIELD );
+		public function settings_page() {
+			$options     = $this->getSetOptions( self::OPT_FIELD );
 			$date_format = get_option( 'date_format' );
 			$time_format = get_option( 'time_format' );
 			?>
@@ -583,21 +583,21 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		<?php
 		}
 
-		public static function admin_settings_init() {
-			register_setting( self::OPT_FIELD, self::OPT_FIELD, array( __CLASS__, "sc_wpun_settings_validate" ) ); // Register Main Settings
-			add_settings_section( "sc_wpun_settings_main", __( "Settings", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_text" ), "wp-updates-notifier" ); // Make settings main section
-			add_settings_field( "sc_wpun_settings_main_cron_method", __( "Cron Method", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_cron_method" ), "wp-updates-notifier", "sc_wpun_settings_main" );
-			add_settings_field( "sc_wpun_settings_main_frequency", __( "Frequency to check", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_frequency" ), "wp-updates-notifier", "sc_wpun_settings_main" );
-			add_settings_field( "sc_wpun_settings_main_notify_to", __( "Notify email to", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_notify_to" ), "wp-updates-notifier", "sc_wpun_settings_main" );
-			add_settings_field( "sc_wpun_settings_main_notify_from", __( "Notify email from", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_notify_from" ), "wp-updates-notifier", "sc_wpun_settings_main" );			
-			add_settings_field( "sc_wpun_settings_main_notify_plugins", __( "Notify about plugin updates?", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_notify_plugins" ), "wp-updates-notifier", "sc_wpun_settings_main" );
-			add_settings_field( "sc_wpun_settings_main_notify_themes", __( "Notify about theme updates?", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_notify_themes" ), "wp-updates-notifier", "sc_wpun_settings_main" );
-			add_settings_field( "sc_wpun_settings_main_notify_automatic", __( "Notify automatic core updates to this address?", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_notify_automatic" ), "wp-updates-notifier", "sc_wpun_settings_main" );
-			add_settings_field( "sc_wpun_settings_main_hide_updates", __( "Hide core WP update nag from non-admin users?", "wp-updates-notifier" ), array( __CLASS__, "sc_wpun_settings_main_field_hide_updates" ), "wp-updates-notifier", "sc_wpun_settings_main" );
+		public function admin_settings_init() {
+			register_setting( self::OPT_FIELD, self::OPT_FIELD, array( $this, "sc_wpun_settings_validate" ) ); // Register Main Settings
+			add_settings_section( "sc_wpun_settings_main", __( "Settings", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_text" ), "wp-updates-notifier" ); // Make settings main section
+			add_settings_field( "sc_wpun_settings_main_cron_method", __( "Cron Method", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_cron_method" ), "wp-updates-notifier", "sc_wpun_settings_main" );
+			add_settings_field( "sc_wpun_settings_main_frequency", __( "Frequency to check", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_frequency" ), "wp-updates-notifier", "sc_wpun_settings_main" );
+			add_settings_field( "sc_wpun_settings_main_notify_to", __( "Notify email to", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_notify_to" ), "wp-updates-notifier", "sc_wpun_settings_main" );
+			add_settings_field( "sc_wpun_settings_main_notify_from", __( "Notify email from", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_notify_from" ), "wp-updates-notifier", "sc_wpun_settings_main" );			
+			add_settings_field( "sc_wpun_settings_main_notify_plugins", __( "Notify about plugin updates?", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_notify_plugins" ), "wp-updates-notifier", "sc_wpun_settings_main" );
+			add_settings_field( "sc_wpun_settings_main_notify_themes", __( "Notify about theme updates?", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_notify_themes" ), "wp-updates-notifier", "sc_wpun_settings_main" );
+			add_settings_field( "sc_wpun_settings_main_notify_automatic", __( "Notify automatic core updates to this address?", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_notify_automatic" ), "wp-updates-notifier", "sc_wpun_settings_main" );
+			add_settings_field( "sc_wpun_settings_main_hide_updates", __( "Hide core WP update nag from non-admin users?", "wp-updates-notifier" ), array( $this, "sc_wpun_settings_main_field_hide_updates" ), "wp-updates-notifier", "sc_wpun_settings_main" );
 		}
 
-		public static function sc_wpun_settings_validate( $input ) {
-			$valid = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_validate( $input ) {
+			$valid = $this->getSetOptions( self::OPT_FIELD );
 
 			if ( isset( $input['cron_method'] ) && in_array( $input['cron_method'], array( "wordpress", "other" ) ) ) {
 				$valid['cron_method'] = $input['cron_method'];
@@ -610,7 +610,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 				$input['frequency'] = "manual";
 			}
 
-			if ( in_array( $input['frequency'], self::get_intervals() ) ) {
+			if ( in_array( $input['frequency'], $this->get_intervals() ) ) {
 				$valid['frequency'] = $input['frequency'];
 				do_action( "sc_wpun_enable_cron", $input['frequency'] );
 			}
@@ -680,7 +680,7 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 			}
 
 			if ( isset( $_POST['submitwithemail'] ) ) {
-				add_filter( 'pre_set_transient_settings_errors', array( __CLASS__, "send_test_email" ) );
+				add_filter( 'pre_set_transient_settings_errors', array( $this, "send_test_email" ) );
 			}
 
 			if ( isset( $input['cron_method'] ) && in_array( $input['cron_method'], array( "wordpress", "other" ) ) ) {
@@ -693,17 +693,17 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 			return $valid;
 		}
 
-		public static function send_test_email( $settings_errors ) {
+		public function send_test_email( $settings_errors ) {
 			if ( isset( $settings_errors[0]['type'] ) && $settings_errors[0]['type'] == "updated" ) {
-				self::send_notification_email( __( "This is a test message from WP Updates Notifier.", "wp-updates-notifier" ) );
+				$this->send_notification_email( __( "This is a test message from WP Updates Notifier.", "wp-updates-notifier" ) );
 			}
 		}
 
-		public static function sc_wpun_settings_main_text() {
+		public function sc_wpun_settings_main_text() {
 		}
 
-		public static function sc_wpun_settings_main_field_cron_method() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_cron_method() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<select name="<?php echo self::OPT_FIELD; ?>[cron_method]">
 				<option value="wordpress" <?php selected( $options['cron_method'], "wordpress" ); ?>><?php _e( "WordPress Cron", "wp-updates-notifier" ); ?></option>
@@ -717,32 +717,32 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		<?php
 		}
 
-		public static function sc_wpun_settings_main_field_frequency() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_frequency() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<select id="sc_wpun_settings_main_frequency" name="<?php echo self::OPT_FIELD; ?>[frequency]">
-			<?php foreach ( self::get_schedules() as $k => $v ): ?>
+			<?php foreach ( $this->get_schedules() as $k => $v ): ?>
 				<option value="<?php echo $k; ?>" <?php selected( $options['frequency'], $k ); ?>><?php echo $v['display']; ?></option>
 			<?php endforeach; ?>
 			<select>
 		<?php
 		}
 
-		public static function sc_wpun_settings_main_field_notify_to() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_notify_to() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<input id="sc_wpun_settings_main_notify_to" class="regular-text" name="<?php echo self::OPT_FIELD; ?>[notify_to]" value="<?php echo $options['notify_to']; ?>" />
 			<span class="description"><?php _e( "Separate multiple email address with a comma (,)", "wp-updates-notifier" ); ?></span><?php
 		}
 
-		public static function sc_wpun_settings_main_field_notify_from() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_notify_from() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<input id="sc_wpun_settings_main_notify_from" class="regular-text" name="<?php echo self::OPT_FIELD; ?>[notify_from]" value="<?php echo $options['notify_from']; ?>" /><?php
 		}
 
-		public static function sc_wpun_settings_main_field_notify_plugins() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_notify_plugins() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<label><input name="<?php echo self::OPT_FIELD; ?>[notify_plugins]" type="radio" value="0" <?php checked( $options['notify_plugins'], 0 ); ?> /> <?php _e( "No", "wp-updates-notifier" ); ?>
 			</label><br />
@@ -753,8 +753,8 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		<?php
 		}
 
-		public static function sc_wpun_settings_main_field_notify_themes() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_notify_themes() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<label><input name="<?php echo self::OPT_FIELD; ?>[notify_themes]" type="radio" value="0" <?php checked( $options['notify_themes'], 0 ); ?> /> <?php _e( "No", "wp-updates-notifier" ); ?>
 			</label><br />
@@ -765,16 +765,16 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		<?php
 		}
 
-		public static function sc_wpun_settings_main_field_notify_automatic() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_notify_automatic() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<label><input name="<?php echo self::OPT_FIELD; ?>[notify_automatic]" type="checkbox" value="1" <?php checked( $options['notify_automatic'], 1 ); ?> /> <?php _e( "Yes", "wp-updates-notifier" ); ?>
 			</label>
 		<?php
 		}
 
-		public static function sc_wpun_settings_main_field_hide_updates() {
-			$options = self::getSetOptions( self::OPT_FIELD );
+		public function sc_wpun_settings_main_field_hide_updates() {
+			$options = $this->getSetOptions( self::OPT_FIELD );
 			?>
 			<select id="sc_wpun_settings_main_hide_updates" name="<?php echo self::OPT_FIELD; ?>[hide_updates]">
 				<option value="1" <?php selected( $options['hide_updates'], 1 ); ?>><?php _e( "Yes", "wp-updates-notifier" ); ?></option>
@@ -786,5 +786,4 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 	}
 }
 
-sc_WPUpdatesNotifier::init();
-?>
+new sc_WPUpdatesNotifier;

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -4,7 +4,7 @@ Plugin Name: WP Updates Notifier
 Plugin URI: https://github.com/l3rady/wp-updates-notifier
 Description: Sends email to notify you if there are any updates for your WordPress site. Can notify about core, plugin and theme updates.
 Contributors: l3rady, eherman24
-Version: 1.4.3
+Version: 1.4.4
 Author: Scott Cariss
 Author URI: http://l3rady.com/
 Text Domain: wp-updates-notifier

--- a/wp-updates-notifier.php
+++ b/wp-updates-notifier.php
@@ -39,11 +39,16 @@ if ( !class_exists( 'sc_WPUpdatesNotifier' ) ) {
 		const OPT_VERSION       = "5.0";
 		const CRON_NAME         = "sc_wpun_update_check";
 
+		static $didInit = false;
+
 		public function __construct() {
-			$this->init();
+			if (!self::$didInit) {
+				$this->init();
+				self::$didInit = true;
+			}
 		}
 
-		protected function init() {
+		private function init() {
 			// Check settings are up to date
 			$this->settingsUpToDate();
 			// Create Activation and Deactivation Hooks


### PR DESCRIPTION
Provides PHP 7 compatibility and fixes E_STRICT-Spam in PHP 5.4+.
Fixes at least three support tickets and #24.

Previously the plugin used PHP 4 style static access. Changes this to use an object instance instead.

There are still severe violations of common OOP programming (like not being SOLID in all 5 categories), but as a pure namespace wrapper this should suffice.

